### PR TITLE
Fix error PDUs and server and client error handling.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.40.0, stable, beta, nightly]
+        rust: [1.42.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Breaking Changes
 * `pdu::Error` has been changed to contain an allocated octets buffer
   instead of being generic in a very fragile way. Consequently,
   `pdu::BoxedError` has been dropped. ([#6])
+* The minimum supported Rust version is now 1.42. ([#6])
 
 Bug Fixes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,15 +4,27 @@
 
 Breaking Changes
 
+* `pdu::Error` has been changed to contain an allocated octets buffer
+  instead of being generic in a very fragile way. Consequently,
+  `pdu::BoxedError` has been dropped. ([#6])
+
 Bug Fixes
+
+* The server now correctly responds to received error PDUs by returning an
+  error from `server::Connection::run`. ([#6])
 
 New
 
 * Implemented `Default` for `state::Serial` [(#4])
+* The client will now send a (generic) error PDU if `VrpTarget::apply`
+  returns an error. This is a temporary measure. In a future version we
+  will provide proper ways to signal displeasure with the supplied data
+  both in `VrpTarget` and `VrpUpdate`. ([#6])
 
 Other Changes
 
 [#4]: https://github.com/NLnetLabs/rpki-rtr/pull/4
+[#6]: https://github.com/NLnetLabs/rpki-rtr/pull/6
 
 
 ## 0.1.1

--- a/src/client.rs
+++ b/src/client.rs
@@ -266,7 +266,15 @@ where
                 }
             }
         }
-        self.target.apply(target, false, self.timing)?;
+        if let Err(err) = self.target.apply(target, false, self.timing) {
+            // XXX Temporary error message. We need to fix error handling
+            //     properly.
+            pdu::Error::new(
+                self.version.unwrap_or(1),
+                0, "", b"corrupt data"
+            ).write(&mut self.sock).await?;
+            return Err(err)
+        }
         Ok(true)
     }
 
@@ -300,7 +308,15 @@ where
                 }
             }
         }
-        self.target.apply(target, true, self.timing)?;
+        if let Err(err) = self.target.apply(target, true, self.timing) {
+            // XXX Temporary error message. We need to fix error handling
+            //     properly.
+            pdu::Error::new(
+                self.version.unwrap_or(1),
+                0, "", b"corrupt data"
+            ).write(&mut self.sock).await?;
+            return Err(err)
+        }
         Ok(())
     }
 
@@ -382,7 +398,7 @@ impl FirstReply {
                     header, sock
                 ).await.map(FirstReply::Reset)
             }
-            pdu::ERROR_PDU => {
+            pdu::Error::PDU => {
                 Err(io::Error::new(
                     io::ErrorKind::Other,
                     format!("server reported error {}", header.session())

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -102,18 +102,12 @@ pub enum Action {
 impl Action {
     /// Returns whether the action is to announce.
     pub fn is_announce(self) -> bool {
-        match self {
-            Action::Announce => true,
-            _ => false,
-        }
+        matches!(self, Action::Announce)
     }
 
     /// Returns whether the action is to withdraw.
     pub fn is_withdraw(self) -> bool {
-        match self {
-            Action::Withdraw=> true,
-            _ => false,
-        }
+        matches!(self, Action::Withdraw)
     }
 
     /// Creates the action from the flags field of an RTR PDU.

--- a/src/server.rs
+++ b/src/server.rs
@@ -266,6 +266,10 @@ where Sock: AsyncRead + Unpin {
                     }
                 }
             }
+            pdu::Error::PDU => {
+                debug!("RTR: Got error reply.");
+                Err(io::Error::new(io::ErrorKind::Other, "got error PDU"))
+            }
             pdu => {
                 debug!("RTR: Got query with PDU {}.", pdu);
                 Ok(Some(Query::Error(

--- a/src/server.rs
+++ b/src/server.rs
@@ -274,7 +274,7 @@ where Sock: AsyncRead + Unpin {
                         3,
                         header,
                         "expected Serial Query or Reset Query"
-                    ).boxed()
+                    )
                 )))
             }
         }
@@ -296,7 +296,7 @@ where Sock: AsyncRead + Unpin {
                         8,
                         header,
                         "version switched during connection"
-                    ).boxed()
+                    )
                 ))
             }
             else {
@@ -310,7 +310,7 @@ where Sock: AsyncRead + Unpin {
                     4,
                     header,
                     "only versions 0 and 1 supported"
-                ).boxed()
+                )
             ))
         }
         else {
@@ -330,7 +330,7 @@ where Sock: AsyncRead + Unpin {
                     3,
                     header,
                     "invalid length"
-                ).boxed()
+                )
             ))
         }
         else {
@@ -356,7 +356,7 @@ where
         debug!("RTR server: request for serial {}", state.serial());
         if !self.source.ready() {
             return pdu::Error::new(
-                self.version(), 2, (), *b"Running initial validation"
+                self.version(), 2, b"", b"Running initial validation"
             ).write(&mut self.sock).await;
         }
         match self.source.diff(state) {
@@ -391,7 +391,7 @@ where
     async fn reset(&mut self) -> Result<(), io::Error> {
         if !self.source.ready() {
             return pdu::Error::new(
-                self.version(), 2, (), *b"Running initial validation"
+                self.version(), 2, "", b"Running initial validation"
             ).write(&mut self.sock).await;
         }
         let (state, iter) = self.source.full();
@@ -411,7 +411,7 @@ where
 
     /// Sends an error response.
     async fn error(
-        &mut self, err: pdu::BoxedError
+        &mut self, err: pdu::Error
     ) -> Result<(), io::Error> {
         err.write(&mut self.sock).await
     }
@@ -439,7 +439,7 @@ enum Query {
     Reset,
 
     /// The client misbehaved resulting in this error to be sent to it.
-    Error(pdu::BoxedError),
+    Error(pdu::Error),
 
     /// The source has new data available.
     Notify


### PR DESCRIPTION
This changes the current very fragile `pdu::Error` to contain an allocated octets sequence and drops `pdu::BoxedError`.

The server will not correctly close the connection when receiving an error PDU instead of responding with an error of its own.

The client will now send an error response when `VrpTarget::apply` errors out. This is a temporary measure until we provide better error handling in the client.