### PR TITLE
Proper client error handling. Single update for client.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ Breaking Changes
 * `pdu::Error` has been changed to contain an allocated octets buffer
   instead of being generic in a very fragile way. Consequently,
   `pdu::BoxedError` has been dropped. ([#6])
+* The client traits `VrpTarget` and `VrpUpdate` have been modified to
+  allow returning errors when processing data. ([#7])
 * The minimum supported Rust version is now 1.42. ([#6])
 
 Bug Fixes
@@ -17,15 +19,15 @@ Bug Fixes
 New
 
 * Implemented `Default` for `state::Serial` [(#4])
-* The client will now send a (generic) error PDU if `VrpTarget::apply`
-  returns an error. This is a temporary measure. In a future version we
-  will provide proper ways to signal displeasure with the supplied data
-  both in `VrpTarget` and `VrpUpdate`. ([#6])
+* The client now provides a method `Client::update` that can be used to
+  fetch a single update instead of just letting it run forever. ([#7])
+
 
 Other Changes
 
 [#4]: https://github.com/NLnetLabs/rpki-rtr/pull/4
 [#6]: https://github.com/NLnetLabs/rpki-rtr/pull/6
+[#7]: https://github.com/NLnetLabs/rpki-rtr/pull/7
 
 
 ## 0.1.1

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -12,13 +12,15 @@ pub struct Store {
 impl VrpTarget for Store {
     type Update = Vec<(Action, Payload)>;
 
-    fn start(&mut self, _: bool) -> Self::Update {
+    fn start(&mut self, reset: bool) -> Self::Update {
+        println!("Starting update (reset={})", reset);
         Vec::new()
     }
 
     fn apply(
         &mut self, update: Self::Update, reset: bool, _timing: Timing
     ) -> Result<(), VrpError> {
+        println!("Update complete: {} entries", update.len());
         if reset {
             self.payload.clear();
         }
@@ -40,7 +42,7 @@ impl VrpTarget for Store {
 
 #[tokio::main]
 async fn main() -> Result<(), io::Error> {
-    let sock = TcpStream::connect("127.0.0.1:3323").await?;
+    let sock = TcpStream::connect("127.0.0.1:9001").await?;
     let mut client = Client::new(sock, Store::default(), None);
     client.run().await
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::collections::HashSet;
 use rpki_rtr::payload::{Action, Payload, Timing};
-use rpki_rtr::client::{Client, VrpTarget};
+use rpki_rtr::client::{Client, VrpError, VrpTarget};
 use tokio::net::TcpStream;
 
 #[derive(Clone, Default)]
@@ -18,7 +18,7 @@ impl VrpTarget for Store {
 
     fn apply(
         &mut self, update: Self::Update, reset: bool, _timing: Timing
-    ) -> Result<(), io::Error> {
+    ) -> Result<(), VrpError> {
         if reset {
             self.payload.clear();
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -297,7 +297,7 @@ where
     }
 
     /// Performs a reset query.
-    async fn reset(&mut self) -> Result<Target::Update, io::Error> {
+    pub async fn reset(&mut self) -> Result<Target::Update, io::Error> {
         pdu::ResetQuery::new(
             self.version.unwrap_or(1)
         ).write(&mut self.sock).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -273,6 +273,9 @@ where
 
         if let Some(state) = self.state {
             if let Some(update) = self.serial(state).await? {
+                self.next_update = Some(
+                    Instant::now() + self.timing.refresh_duration()
+                );
                 return Ok(update)
             }
         }
@@ -287,7 +290,7 @@ where
     /// Perform a serial query.
     ///
     /// Returns some update if the query succeeded and the client should now
-    /// wait for a while. Returns `Non` if the server reported a restart and
+    /// wait for a while. Returns `None` if the server reported a restart and
     /// we need to proceed with a reset query. Returns an error
     /// in any other case.
     async fn serial(

--- a/src/client.rs
+++ b/src/client.rs
@@ -175,6 +175,16 @@ impl<Sock, Target> Client<Sock, Target> {
         }
     }
 
+    /// Returns a reference to the target.
+    pub fn target(&self) -> &Target {
+        &self.target
+    }
+
+    /// Returns a mutable reference to the target.
+    pub fn target_mut(&mut self) -> &mut Target {
+        &mut self.target
+    }
+
     /// Converts the client into its target.
     pub fn into_target(self) -> Target {
         self.target

--- a/src/client.rs
+++ b/src/client.rs
@@ -260,6 +260,12 @@ where
         }
     }
 
+    /// Performs a single update of the client data.
+    ///
+    /// The method will wait until the next update is due and the request one
+    /// single update from the server. It will request a new update object
+    /// from the target, apply the update to that object and, if the update
+    /// succeeds, return the object.
     pub async fn update(
         &mut self
     ) -> Result<Target::Update, io::Error> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -169,6 +169,11 @@ impl<Sock, Target> Client<Sock, Target> {
         }
     }
 
+    /// Converts the client into its target.
+    pub fn into_target(self) -> Target {
+        self.target
+    }
+
     /// Returns the current state of the session.
     ///
     /// The method will return `None` if there hasn’t been initial state and

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -8,6 +8,7 @@
 //! they become necessary. So don’t hesitate to ask for them!
 
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::time::Duration;
 
 
 //------------ IPv4Prefix ----------------------------------------------------
@@ -152,6 +153,12 @@ pub struct Timing {
 
     /// The number of secionds before data expires if not refreshed.
     pub expire: u32
+}
+
+impl Timing {
+    pub fn refresh_duration(self) -> Duration {
+        Duration::from_secs(u64::from(self.refresh))
+    }
 }
 
 impl Default for Timing {

--- a/src/pdu.rs
+++ b/src/pdu.rs
@@ -582,7 +582,7 @@ impl Payload {
     }
 
     /// Converts the payload PDU into action and payload.
-    pub fn into_payload(self) -> (payload::Action, payload::Payload) {
+    pub fn to_payload(&self) -> (payload::Action, payload::Payload) {
         (
             payload::Action::from_flags(self.flags()),
             match self {


### PR DESCRIPTION
This PR introduces proper data error reporting to `VrpTarget` and `VrpUpdate`.

It also introduces a method `Client::update` that can be used to request a single data update from the server.